### PR TITLE
Task/Add Rate limit protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schematics": "^11.0.0",
         "@nestjs/testing": "^11.0.1",
+        "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.11.29",
@@ -2604,6 +2605,18 @@
         "@nestjs/platform-express": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/throttler": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-6.4.0.tgz",
+      "integrity": "sha512-osL67i0PUuwU5nqSuJjtUJZMkxAnYB4VldgYUMGzvYRJDCqGRFMWbsbzm/CkUtPLRL30I8T74Xgt/OQxnYokiA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
+        "reflect-metadata": "^0.1.13 || ^0.2.0"
       }
     },
     "node_modules/@nestjs/typeorm": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
+    "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.11.29",

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
+import { minutes, ThrottlerGuard, ThrottlerModule } from '@nestjs/throttler';
 import { UsersModule } from 'src/users/users.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -14,9 +16,22 @@ import { AuthService } from './auth.service';
         secret: configService.get<string>('JWT_SECRET')
       }),
       global: true
+    }),
+    ThrottlerModule.forRootAsync({
+      inject: [ConfigService],
+      useFactory: (configService: ConfigService) => [{
+        ttl: configService.get<number>('THROTTLE_TTL') ?? minutes(1),
+        limit: configService.get<number>('THROTTLE_LIMIT') ?? 10
+      }]
     })
   ],
   controllers: [AuthController],
-  providers: [AuthService]
+  providers: [
+    AuthService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard
+    }
+  ]
 })
 export class AuthModule { }


### PR DESCRIPTION
Adds Rate limit protection.
Applies to all requests the same, limit of 10 requests per minute.